### PR TITLE
Initial documentation setup

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,28 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 1.0
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+   - pdf
+   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+geopandas
+rioxarray
+requests
+matplotlib


### PR DESCRIPTION
Adds initial versions of files/directories needed for readthedocs documentation. 

Once merged, I request that the repo host takes the following steps to create a readthedocs project:

- Create a readthedocs account, and [link it to your github account](https://docs.readthedocs.io/en/stable/guides/connecting-git-account.html). Note: when I created a readthedocs account, the verification email was blocked by IT. I recommend emailing spam.abuse@usda.gov and requesting that they don't block emails from support@readthedocs.org
- From your new readthedocs account, click "Projects" from the top right dropdown menu, then "Import a project". Select the pygcdl repo if it pops up, or manually type in the url to the pygcdl repo. Name the project "pygcdl".